### PR TITLE
fix(api): load correct relations on store response and include counts

### DIFF
--- a/app/Http/Controllers/Api/V1/PostsController.php
+++ b/app/Http/Controllers/Api/V1/PostsController.php
@@ -27,7 +27,9 @@ class PostsController extends Controller
 
         $post = Post::create($data);
 
-        return response()->json($post->load('user_id,username'),201);
+        $post->load(['user:id,username'])->loadCount(['comments','likes']);
+
+        return response()->json($post,201);
     }
 
     //DELETE /api/v1/posts/{post}


### PR DESCRIPTION
store: $post->load(['user:id,username'])->loadCount(['comments','likes'])
- index: with user + withCount + desc order
- フロントの即時反映に必要なフィールドを返却