### PR TITLE
API: 投稿バリデーションとレスポンス整合性の改善

### DIFF
--- a/app/Http/Controllers/Api/V1/PostsController.php
+++ b/app/Http/Controllers/Api/V1/PostsController.php
@@ -22,7 +22,7 @@ class PostsController extends Controller
         //※後でFirebase認証に書き換え予定。今はuser_idを受け取る。
         $data = $request->validate([
             'user_id' => ['required', 'integer', 'exists:users,id'],
-            'content' => ['required', 'string', 'max:120'],
+            'content' => ['required', 'string', 'grapheme_max:120'],
         ]);
 
         $post = Post::create($data);

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Validator;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -19,6 +20,23 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Validator::extend('grapheme_max', function ($attribute, $value, $parameters) {
+            $max = (int)($parameters[0] ?? 120);
+            $text = trim((string) $value);
+            if (function_exists('grapheme_strlen')) {
+                $len = grapheme_strlen($text);
+            } elseif (function_exists('mb_strlen')) {
+                $len = mb_strlen($text, 'UTF-8');
+            } else {
+                $len = strlen($text);
+            }
+            return $len <= $max;
+        }, ':attribute は :max 文字以内で入力してください。');
+
+        // :max を数値に置換
+        Validator::replacer('grapheme_max', function ($message, $attribute, $rule, $parameters) {
+            $max = (int)($parameters[0] ?? 0);
+            return str_replace(':max', (string) $max, $message);
+        });
     }
 }


### PR DESCRIPTION
概要

AppServiceProvider に grapheme_max ルールを追加（grapheme_strlen で 120 文字上限を厳密化）

POST /api/v1/posts の返却を load(['user:id,username'])->loadCount(['comments','likes']) に修正

動作確認

正常: curl -s -X POST http://127.0.0.1:8000/api/v1/posts -d "user_id=1&content=こんにちは" → 201 & user/*_count が付いて返る

異常: 121 文字以上（絵文字込み）で 422 が返ること