### PR TITLE
feat(api): コメント削除APIを追加（DELETE /posts/{post}/comments/{comment}）

### DIFF
--- a/app/Http/Controllers/Api/V1/CommentsController.php
+++ b/app/Http/Controllers/Api/V1/CommentsController.php
@@ -42,4 +42,21 @@ class CommentsController extends Controller
 
         return response()->json($comment, 201);
     }
+
+    // DELETE /api/v1/posts/{post}/comments/{comment}
+    public function destroy(Post $post, Comment $comment)
+    {
+        // 簡易認可（本来はPolicyかAuthで判定）
+        // 暫定: user_id=1 だけ削除可
+        if ((int)$comment->user_id !== 1) {
+            return response()->json(['message' => 'Forbidden'], 403);
+        }
+        // 紐付け整合（別ポストのコメント削除防止）
+        if ((int)$comment->post_id !== (int)$post->id) {
+            return response()->json(['message' => 'Not Found'], 404);
+        }
+        $comment->delete();
+        return response()->json(['deleted' => true]);
+    }
 }
+

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,6 +20,7 @@ Route::prefix('v1')->group(function () {
     // Comments
     Route::get('/posts/{post}/comments', [CommentsController::class, 'index'])->whereNumber('post');
     Route::post('/posts/{post}/comments', [CommentsController::class, 'store'])->whereNumber('post');
+    Route::delete('posts/{post}/comments/{comment}', [CommentsController::class, 'destroy']);
 
     // Likes (toggle)
     Route::post('/posts/{post}/likes/toggle', [LikesController::class, 'toggle'])->whereNumber('post');


### PR DESCRIPTION
## 概要
投稿に紐づくコメントの削除 API を追加しました。  
コメントの所有者（暫定: user_id=1）のみ削除可能としています（本来は認証・Policyで制御予定）。

## 変更内容
- `routes/api.php`
  - `DELETE /api/v1/posts/{post}/comments/{comment}` を追加
- `App\Http\Controllers\Api\V1\CommentsController`
  - `destroy(Post $post, Comment $comment)` を実装
  - 同一ポストに紐づくコメントかチェック
  - 暫定ロジック：`user_id=1` のコメントのみ削除許可（将来Authに置換）

## 動作確認
```bash
# 例：投稿ID=1、コメントID=2 を削除
curl -s -X DELETE http://127.0.0.1:8000/api/v1/posts/1/comments/2
# => {"deleted":true}
```
・存在しない/別ポストのコメントは 404 を返すこと
・所有者以外が削除しようとした場合は 403 を返すこと（暫定仕様）

## 影響範囲
- バックエンド API（`routes/api.php`, `CommentsController`）
- 今後、フロントエンド `/posts/[id].vue` のコメント一覧に「削除」ボタンを追加予定（楽観更新で UI から即時除去）

## 関連
- 既存のコメント作成 API：`POST /api/v1/posts/{post}/comments`
- 一覧取得 API：`GET /api/v1/posts/{post}/comments`

## チェックリスト
- [x] ローカルで動作確認済み（`{"deleted":true}` が返る）
- [x] 不正なパラメータ時のエラーハンドリング（404/403）を確認
- [x] 既存 API（投稿作成/一覧/いいね）との整合を確認
- [x] 今後 Auth 実装時に暫定ロジックの置き換えが容易な構成
