### PR TITLE
投稿更新APIを実装（PUT /api/v1/posts/{post}）

### DIFF
--- a/app/Http/Controllers/Api/V1/PostsController.php
+++ b/app/Http/Controllers/Api/V1/PostsController.php
@@ -48,4 +48,19 @@ class PostsController extends Controller
 
         return response()->json($post);
     }
+
+    public function update(Request $request, Post $post)
+    {
+        //TODO:認可(本人のみ編集)は後でPolicyで実装。今は省略
+        $data = $request->validate([
+            'content' => ['required', 'string', 'grapheme_max:120'],
+        ]);
+
+        $post->update(['content' => trim($data['content'])]);
+
+        //一覧と同じ整合性のある返却
+        $post->load(['user:id,username'])->loadCount(['comments','likes']);
+
+        return response()->json($post);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,6 +16,7 @@ Route::prefix('v1')->group(function () {
     Route::post('/posts', [PostsController::class, 'store']);
     Route::delete('/posts/{post}', [PostsController::class, 'destroy']);
     Route::get('/posts/{post}', [PostsController::class, 'show'])->whereNumber('post');
+    Route::put('/posts/{post}', [PostsController::class, 'update']);
 
     // Comments
     Route::get('/posts/{post}/comments', [CommentsController::class, 'index'])->whereNumber('post');


### PR DESCRIPTION
## 概要
投稿の本文を更新する API (`PUT /api/v1/posts/{post}`) を実装しました。  
これにより既存投稿の本文を120文字以内で編集できるようになりました。

## 変更内容
- `routes/api.php`
  - `Route::put('/posts/{post}', [PostsController::class, 'update']);` を追加
- `PostsController`
  - `update` メソッドを新規実装
    - バリデーション: `required|string|grapheme_max:120`
    - 更新処理後、`user`・`comments_count`・`likes_count` をロードして返却

## 動作確認
- 投稿を正常に更新できること
```bash
curl -s -X PUT http://127.0.0.1:8000/api/v1/posts/1 \
  -H "Content-Type: application/json" \
  -H "Accept: application/json" \
  -d '{"content":"編集後の本文(最大120文字)"}'
```
- 121文字入力した場合、バリデーションエラーが返却されること
```bash
python3 - <<'PY'
import json, subprocess
txt = "あ" * 121
payload = json.dumps({"content": txt})
res = subprocess.run(
    ["curl","-s","-X","PUT",
     "http://127.0.0.1:8000/api/v1/posts/1",
     "-H","Content-Type: application/json",
     "-H","Accept: application/json",
     "-d", payload],
    capture_output=True, text=True
)
print(res.stdout)
PY
```
## 影響範囲
- バックエンド API
  - `PostsController@update`
  - `routes/api.php` のルート追加

## 関連
- フロントエンド `/posts/[id].vue` に編集フォームを実装予定

## チェックリスト
- [x] ローカルで正常に動作確認済み
- [x] 正常系で更新できることを確認
- [x] 異常系（121文字以上）でバリデーションエラーが返却されることを確認