### PR TITLE
feat(api): 画像投稿APIの追加と画像のみ投稿の許可

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,8 @@ APP_URL=http://127.0.0.1:8000
 
 LOG_CHANNEL=stack
 
-
 DB_CONNECTION=sqlite
+
+POST_IMAGE_MAX_MB=15
 
 

--- a/app/Http/Controllers/Api/V1/PostsController.php
+++ b/app/Http/Controllers/Api/V1/PostsController.php
@@ -3,10 +3,11 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\StorePostRequest;
 use App\Models\Post;
 use App\Models\PostImage;
 use Illuminate\Http\Request;
-use App\Http\Requests\StorePostRequest;
+use Illuminate\Support\Facades\DB;        // ★ これが必須（今回の本命）
 use Illuminate\Support\Facades\Storage;
 
 class PostsController extends Controller
@@ -14,7 +15,6 @@ class PostsController extends Controller
     // GET /api/v1/posts
     public function index(Request $request)
     {
-        // ※ with() は「user_id」ではなくリレーション名「user」を使う
         return Post::with(['user:id,username,name', 'images'])
             ->latest()
             ->paginate(20);
@@ -23,25 +23,55 @@ class PostsController extends Controller
     // POST /api/v1/posts
     public function store(StorePostRequest $request)
     {
-        /** @var \App\Models\User|null $auth */
-        $auth = $request->attributes->get('auth_user');
-
-        // 認証必須：auth_user が無い時に 401 を返す（← 逆になっていた）
-        if (!$auth) {
-            return response()->json(['message' => '認証されていません'], 401);
+        /** @var \App\Models\User|null $user */
+        $user = $request->user();
+        if (!$user) {
+            return response()->json(['message' => 'Unauthenticated.'], 401);
         }
 
-        // StorePostRequest で検証済み（body を受けて DB の content に入れる）
-        $text = $request->validated()['body'];
+        $validated = $request->validated();
 
-        $post = Post::create([
-            'user_id' => $auth->id,
-            'content' => $text,
-        ]);
+        return DB::transaction(function () use ($user, $request, $validated) {
+            $post = new Post();
+            $post->user_id = $user->id;
+            $post->content = $validated['content'] ?? null;
+            $post->save();
 
-        $post->loadMissing(['user:id,username,name'])->loadCount(['comments', 'likes']);
+            // 画像は単体/配列の両方に耐える
+            $files = $request->file('images', []);
+            if ($files && !is_array($files)) {
+                $files = [$files];
+            }
 
-        return response()->json($post, 201);
+            foreach (array_values($files) as $idx => $file) {
+                // storage/app/public/post-images に保存
+                $storedPath = Storage::disk('public')->putFile('post-images', $file);
+
+                // 画像サイズ（取得失敗時は null）
+                $w = null;
+                $h = null;
+                try {
+                    [$w, $h] = @getimagesize($file->getRealPath()) ?: [null, null];
+                } catch (\Throwable $e) {
+                    // noop
+                }
+
+                PostImage::create([
+                    'post_id' => $post->id,
+                    'path'    => $storedPath, // 例: post-images/abc.jpg
+                    'width'   => $w,
+                    'height'  => $h,
+                    'order'   => $idx,
+                ]);
+            }
+
+            $post->load([
+                'user:id,username,name',
+                'images',
+            ])->loadCount(['comments', 'likes']);
+
+            return response()->json($post, 201);
+        });
     }
 
     // DELETE /api/v1/posts/{post}
@@ -54,14 +84,12 @@ class PostsController extends Controller
     // GET /api/v1/posts/{post}
     public function show(Post $post)
     {
-        // ここも「user_id」ではなく「user」
         return $post->load(['user:id,username,name', 'images']);
     }
 
     // PUT /api/v1/posts/{post}
     public function update(Request $request, Post $post)
     {
-        // 「grapheme_max」は未定義なら 500 になるので通常の max を使用
         $data = $request->validate([
             'content' => ['required', 'string', 'max:120'],
         ]);

--- a/app/Http/Requests/StorePostRequest.php
+++ b/app/Http/Requests/StorePostRequest.php
@@ -6,42 +6,37 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class StorePostRequest extends FormRequest
 {
-    /**
-     * Determine if the user is authorized to make this request.
-     */
     public function authorize(): bool
     {
         return true;
     }
 
-    protected function prepareForValidation(): void
-    {
-        if ($this->input('body') === null && $this->filled('content')) {
-            $this->merge(['body' => $this->input('content')]);
-        }
-    }
-
-    /**
-     * Get the validation rules that apply to the request.
-     *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
-     */
     public function rules(): array
     {
+        // ★ 画像1枚あたりの上限(MB)を .env から可変に（既定 15MB）
+        $maxMb = (int) env('POST_IMAGE_MAX_MB', 15);
+        $maxKb = $maxMb * 1024;
+
         return [
-            'body' => ['required', 'string','max:120'],
-            'images' => ['nullable','array','max:4'],
-            'images.*' => ['file','image','mimes:jpeg,jpg,png,webp,gif','max:5120'],
+            'content'   => ['nullable', 'string', 'max:120'],
+            'images'    => ['nullable', 'array', 'max:4'],
+            // ★ 'max:' は KB 指定
+            'images.*'  => ['file', 'image', 'mimes:jpeg,jpg,png,webp,gif', "max:{$maxKb}"],
         ];
     }
 
     public function withValidator($validator)
     {
         $validator->after(function ($v) {
-            $hasBody = filled($this->input('body'));
-            $hasFiles = is_array($this->file('images')) && count($this->file('images')) > 0;
-            if (!$hasBody && !$hasFiles) {
-                $v->errors()->add('body','本文または画像のどちらか1つは必須です。');
+            $content = (string) $this->input('content', '');
+            $hasText = trim($content) !== '';
+
+            $files = $this->file('images');
+            $count = is_array($files) ? count($files) : ($files ? 1 : 0);
+            $hasImages = $this->hasFile('images') && $count > 0;
+
+            if (!$hasText && !$hasImages) {
+                $v->errors()->add('content', '本文または画像のいずれかは必須です。');
             }
         });
     }
@@ -49,8 +44,12 @@ class StorePostRequest extends FormRequest
     public function messages(): array
     {
         return [
-            'body.required' => '本文は必須です',
-            'body.max' => '本文は120文字以内で入力して下さい',
+            'content.max'   => '本文は120文字以内で入力してください。',
+            'images.array'  => '画像の送信形式が不正です。',
+            'images.max'    => '画像は最大4枚までです。',
+            'images.*.image' => '画像ファイルを選択してください。',
+            'images.*.mimes' => '対応形式は jpeg,jpg,png,webp,gif です。',
+            'images.*.max'  => '各画像は :max KB（約 ' . env('POST_IMAGE_MAX_MB', 15) . 'MB）までです。',
         ];
     }
 }

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -36,7 +36,7 @@ class Post extends Model
     //画像一覧
     public function images()
     {
-        return $this->hasMany(\App\Models\PostImage::class)->orderBy('order');
+        return $this->hasMany(PostImage::class)->orderBy('order');
     }
 }
 

--- a/app/Models/PostImage.php
+++ b/app/Models/PostImage.php
@@ -11,13 +11,14 @@ class PostImage extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['post_id','path','order','width','height','mime','size'];
+    protected $fillable = ['post_id','path','order','width','height'];
     protected $appends = ['url'];
 
-    public function post(): BelongsTo { return $this->belongsTo(Post::class);}
+    public function post(): BelongsTo {
+        return $this->belongsTo(Post::class);}
 
     public function getUrlAttribute(): string
     {
-        return Storage::url($this->path);
+        return Storage::disk('public')->url($this->path);
     }
 }

--- a/database/migrations/2025_08_19_033838_create_posts_table.php
+++ b/database/migrations/2025_08_19_033838_create_posts_table.php
@@ -13,8 +13,13 @@ return new class extends Migration
     {
         Schema::create('posts', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id')->constrained()->cascadeOnDelete(); // ユーザー削除時に投稿も削除
-            $table->string('content', 120); // つぶやき本文（120文字以内）
+
+            // ユーザー削除時に投稿も削除
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+
+            // ★ 本文は NULL 許容（画像のみ投稿を許可）
+            $table->string('content', 120)->nullable();
+
             $table->timestamps();
 
             $table->index('user_id');

--- a/database/migrations/2025_09_13_010658_create_post_images_table.php
+++ b/database/migrations/2025_09_13_010658_create_post_images_table.php
@@ -4,30 +4,24 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
-    /**
-     * Run the migrations.
-     */
+return new class extends Migration {
     public function up(): void
     {
         Schema::create('post_images', function (Blueprint $table) {
-            if (!Schema::hasColumn('post_images', 'post_id')) {
-                $table->foreignId('post_id')->constrained('posts')->cascadeOnDelete();
-            }
-            if (!Schema::hasColumn('post_images', 'path')) {
-                $table->string('path'); // storageの相対パスなど
-            }
-            if (!Schema::hasColumn('post_images', 'order')) {
-                $table->unsignedTinyInteger('order')->default(0);
-            }
-            $table->index('post_id');
+            $table->id();
+            $table->foreignId('post_id')
+                ->constrained('posts')
+                ->cascadeOnDelete(); // 投稿削除で画像も削除
+            $table->string('path');            // storage/app/public/... の相対パス
+            $table->unsignedSmallInteger('width')->nullable();
+            $table->unsignedSmallInteger('height')->nullable();
+            $table->unsignedTinyInteger('order')->default(0); // 並び順
+            $table->timestamps();
+
+            $table->index(['post_id', 'order']);
         });
     }
 
-    /**
-     * Reverse the migrations.
-     */
     public function down(): void
     {
         Schema::dropIfExists('post_images');


### PR DESCRIPTION
## 目的
- 画像投稿の学校要件対応（最大4枚/拡張子/容量）と「本文または画像のどちらか必須」
- 画像のみ投稿を許可（posts.content を nullable）

## 変更点
- posts.content を nullable に変更（migrate:fresh 済）
- StorePostRequest: images[*] バリデーション（mimes, max）、本文or画像必須、上限は env: POST_IMAGE_MAX_MB
- PostsController@store: public ディスク保存、width/height 取得、images をレスポンスに含める
- PostImage: url アクセサ（Storage::url）

## 環境
- .env: `POST_IMAGE_MAX_MB=15`（※.env はコミット対象外）
- `php artisan storage:link` 済

## 動作確認
- [x] テキストのみ OK
- [x] 画像のみ 1〜4枚 OK
- [x] 5枚で 422
- [x] 上限超（>15MB）で 422
- [x] TL に画像が表示（/storage/…）
- [x] 既存機能（一覧/ページング/削除/いいね/コメント）に影響なし

## 備考（運用）
- PHP の上限: artisan serve 利用時は `php -d upload_max_filesize=20M -d post_max_size=80M -d memory_limit=512M artisan serve`
