### PR TITLE
feat(storage): 投稿削除時にストレージ上の画像ファイルも削除する

### DIFF
--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\{BelongsTo, HasMany};
+use Illuminate\Support\Facades\Storage;
 
 class Post extends Model
 {
@@ -33,10 +34,24 @@ class Post extends Model
         return $this->hasMany(Like::class);
     }
 
-    //画像一覧
-    public function images()
+    // ★ 画像リレーション（order順）
+    public function images(): HasMany
     {
         return $this->hasMany(PostImage::class)->orderBy('order');
+    }
+
+    // ★ Post削除前に紐づく物理ファイルを削除
+    protected static function booted(): void
+    {
+        static::deleting(function (Post $post) {
+            // 画像テーブルからパスだけ取得して削除（N+1回避）
+            $paths = $post->images()->pluck('path')->all();
+            foreach ($paths as $p) {
+                if ($p) {
+                    Storage::disk('public')->delete($p);
+                }
+            }
+        });
     }
 }
 


### PR DESCRIPTION
## 目的
- 投稿削除時に `storage/app/public/post-images/*` が残らないよう物理ファイルもクリーンアップする

## 変更点
- Postモデルの `deleting` イベントで関連画像の `path` を取得し、`Storage::disk('public')->delete()` を実行
- DB外部キーの cascade は継続使用（Eloquentの子モデルイベントは発火しないため親側で削除処理）

## 動作確認
- [x] 画像付き投稿を作成 → 削除 → 対応ファイルがストレージから消える
- [x] ログにエラーが出ない

## 影響範囲
- 物理ファイル削除のみ。APIレスポンス・スキーマ変更なし
