### PR TITLE
feat: プロフィールアイコンのアップロードAPIを追加

### DIFF
--- a/app/Http/Controllers/Api/V1/MeController.php
+++ b/app/Http/Controllers/Api/V1/MeController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\UpdateProfileRequest;
 use App\Models\User;
 use App\Models\Comment;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
 
 class MeController extends Controller
 {
@@ -19,6 +20,11 @@ class MeController extends Controller
         $commentsCount = Comment::where('user_id', $u->id)->count();
         $likesCount    = $u->receivedLikes()->count(); // このユーザーの投稿についたいいね
 
+        // public ディスクに保存している前提で URL を生成
+        $avatarUrl = $u->avatar_path
+            ? Storage::disk('public')->url($u->avatar_path)
+            : null;
+
         return [
             'id'           => $u->id,
             'name'         => $u->name,
@@ -26,6 +32,8 @@ class MeController extends Controller
             'email'        => $u->email,
             'firebase_uid' => $u->firebase_uid,
             'bio'          => $u->bio,
+            'avatar_path'  => $u->avatar_path,
+            'avatar_url'   => $avatarUrl,
 
             'posts_count'    => $postsCount,
             'comments_count' => $commentsCount,
@@ -44,13 +52,49 @@ class MeController extends Controller
         return response()->json($this->toProfileArray($u));
     }
 
-    // PUT /api/v1/me
+    // PUT /api/v1/me （名前・ユーザー名・自己紹介など）
     public function update(UpdateProfileRequest $request)
     {
         /** @var \App\Models\User $u */
         $u = $request->attributes->get('auth_user');
 
         $u->fill($request->validated());
+        $u->save();
+
+        return response()->json($this->toProfileArray($u));
+    }
+
+    // POST /api/v1/me/avatar （アイコン画像アップロード）
+    public function updateAvatar(Request $request)
+    {
+        /** @var \App\Models\User $u */
+        $u = $request->attributes->get('auth_user');
+
+        // 画像バリデーション（5MBまで / jpg,png,webp,gif）
+        $request->validate([
+            'avatar' => [
+                'required',
+                'image',
+                'mimes:jpeg,jpg,png,webp,gif',
+                'max:5120', // KB 単位 → 約5MB
+            ],
+        ]);
+
+        // バリデーション後は request->file() から確実に取り出す
+        $file = $request->file('avatar');
+        if (!$file) {
+            return response()->json(['message' => 'ファイルが送信されていません'], 422);
+        }
+
+        // 以前のアイコンがあれば削除（あればでOK）
+        if ($u->avatar_path) {
+            Storage::disk('public')->delete($u->avatar_path);
+        }
+
+        // public ディスクに保存（例: avatars/{user_id}/xxxxxx.png）
+        $path = $file->store('avatars/'.$u->id, 'public');
+
+        $u->avatar_path = $path;
         $u->save();
 
         return response()->json($this->toProfileArray($u));

--- a/routes/api.php
+++ b/routes/api.php
@@ -35,6 +35,7 @@ Route::prefix('v1')->group(function () {
         // me
         Route::get('/me', [MeController::class, 'show']);
         Route::put('/me', [MeController::class, 'update']);
+        Route::post('/me/avatar', [MeController::class, 'updateAvatar']);
     });
 });
 


### PR DESCRIPTION
## 概要
- /api/v1/me/avatar エンドポイントを追加
- public ディスクへのアイコン画像保存
- プロフィール取得レスポンスに avatar_url を追加

## 確認内容
- ログインユーザーで /me 取得 → avatar_url が含まれること
- 画像をアップロードすると storage/app/public/avatars/{user_id}/ 以下に保存されること
